### PR TITLE
feat: add opt-in GCP pd-ssd disk and kernel tuning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,10 +224,11 @@ The verify stage (`molecule/default/verify.yml`) validates:
 - `kafka_pd_ssd_tuning: false` - Enable disk + kernel tuning for GCP Persistent Disk SSD. Enable only on GCP hosts (set in `hosts.gcp.ini`).
 - `kafka_pd_ssd_device: ""` - Block device for the data dir, e.g. `/dev/disk/by-id/google-<attach device-name>`. **Required** when tuning is enabled.
 - `kafka_pd_ssd_fstype: xfs` - Filesystem created on the data device (Kafka/Confluent recommend XFS).
+- `kafka_pd_ssd_fs_packages: [xfsprogs]` - mkfs tooling installed before formatting (minimal images lack it). Set to `[e2fsprogs]` for ext4.
 - `kafka_pd_ssd_mount_opts: "noatime,nodiratime"` - Mount options (no `discard`; GCP PD is not a raw SSD).
 - `kafka_pd_ssd_sysctl` - VM tuning dict (`vm.max_map_count=262144`, `vm.dirty_background_ratio=5`, `vm.dirty_ratio=60`).
 
-When enabled, `tasks/gcp-pd-ssd.yml` runs early (after the `vm.swappiness` task, before user/group creation and KRaft format) so the data directory sits on the pd-ssd mount before it is owned/formatted. **Safety contract:** mkfs runs only when `blkid` finds no existing filesystem signature, and `community.general.filesystem` is invoked with `force: false` — an already-provisioned disk is never wiped. Requires the `community.general` collection (see `requirements.yml`).
+When enabled, `tasks/gcp-pd-ssd.yml` runs early (after the `vm.swappiness` task, before user/group creation and KRaft format) so the data directory sits on the pd-ssd mount before it is owned/formatted. **Safety contract:** the `blkid` probe only tolerates rc 0/2 (any other error aborts the play), mkfs runs only when no existing filesystem signature is found, and `community.general.filesystem` is invoked with `force: false` — an already-provisioned disk is never wiped. The mkfs tooling (`kafka_pd_ssd_fs_packages`) is installed before formatting. Requires the `community.general` collection (see `requirements.yml`).
 
 **General Dictionary:**
 - `kafka_server_config_params` - Dictionary for additional server.properties entries

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,6 +220,15 @@ The verify stage (`molecule/default/verify.yml`) validates:
 - `kafka_data_log_dirs: /var/lib/kafka/logs` - Data storage location
 - `kafka_log_dir: /var/log/kafka` - Application log directory
 
+**GCP pd-ssd tuning (opt-in, default off):**
+- `kafka_pd_ssd_tuning: false` - Enable disk + kernel tuning for GCP Persistent Disk SSD. Enable only on GCP hosts (set in `hosts.gcp.ini`).
+- `kafka_pd_ssd_device: ""` - Block device for the data dir, e.g. `/dev/disk/by-id/google-<attach device-name>`. **Required** when tuning is enabled.
+- `kafka_pd_ssd_fstype: xfs` - Filesystem created on the data device (Kafka/Confluent recommend XFS).
+- `kafka_pd_ssd_mount_opts: "noatime,nodiratime"` - Mount options (no `discard`; GCP PD is not a raw SSD).
+- `kafka_pd_ssd_sysctl` - VM tuning dict (`vm.max_map_count=262144`, `vm.dirty_background_ratio=5`, `vm.dirty_ratio=60`).
+
+When enabled, `tasks/gcp-pd-ssd.yml` runs early (after the `vm.swappiness` task, before user/group creation and KRaft format) so the data directory sits on the pd-ssd mount before it is owned/formatted. **Safety contract:** mkfs runs only when `blkid` finds no existing filesystem signature, and `community.general.filesystem` is invoked with `force: false` — an already-provisioned disk is never wiped. Requires the `community.general` collection (see `requirements.yml`).
+
 **General Dictionary:**
 - `kafka_server_config_params` - Dictionary for additional server.properties entries
 

--- a/defaults/main/003-gcp-pd-ssd.yml
+++ b/defaults/main/003-gcp-pd-ssd.yml
@@ -21,6 +21,13 @@ kafka_pd_ssd_device: ""
 # recommended by the Apache Kafka / Confluent operations docs.
 kafka_pd_ssd_fstype: xfs
 
+# Userspace tools that provide mkfs.<kafka_pd_ssd_fstype>. These are not
+# guaranteed to be present on minimal cloud images and are installed
+# (when kafka_pd_ssd_tuning=true) before the filesystem is created.
+# Change to match kafka_pd_ssd_fstype, e.g. ['e2fsprogs'] for ext4.
+kafka_pd_ssd_fs_packages:
+  - xfsprogs
+
 # Mount options for the Kafka data filesystem.
 # noatime/nodiratime drop read-path metadata writes (Kafka is read-heavy).
 # 'discard' is intentionally NOT set: GCP Persistent Disk is not a raw

--- a/defaults/main/003-gcp-pd-ssd.yml
+++ b/defaults/main/003-gcp-pd-ssd.yml
@@ -1,0 +1,43 @@
+---
+############################# GCP pd-ssd tuning #############################
+# Opt-in disk + kernel tuning for Kafka running on Google Cloud
+# Persistent Disk SSD (pd-ssd). Disabled by default; enable ONLY on GCP
+# hosts (set kafka_pd_ssd_tuning=true in the GCP inventory).
+#
+# SAFETY CONTRACT: with kafka_pd_ssd_tuning=true the role creates an XFS
+# filesystem on kafka_pd_ssd_device IF AND ONLY IF the device has no
+# existing filesystem signature. An existing filesystem is never wiped
+# (community.general.filesystem runs with force=false AND the mkfs task
+# is guarded by an explicit blkid probe), so already-provisioned
+# clusters keep their data.
+kafka_pd_ssd_tuning: false
+
+# Block device backing the Kafka data directory. On GCP an attached
+# Persistent Disk appears as /dev/disk/by-id/google-<attach device-name>.
+# REQUIRED (must be non-empty) when kafka_pd_ssd_tuning=true.
+kafka_pd_ssd_device: ""
+
+# Filesystem created on the data device. XFS is the filesystem
+# recommended by the Apache Kafka / Confluent operations docs.
+kafka_pd_ssd_fstype: xfs
+
+# Mount options for the Kafka data filesystem.
+# noatime/nodiratime drop read-path metadata writes (Kafka is read-heavy).
+# 'discard' is intentionally NOT set: GCP Persistent Disk is not a raw
+# SSD, so online TRIM adds overhead with no benefit (a periodic fstrim
+# is sufficient).
+kafka_pd_ssd_mount_opts: "noatime,nodiratime"
+
+# Kernel VM tuning applied (only) when kafka_pd_ssd_tuning=true.
+# vm.max_map_count: Kafka mmaps index files; the 65530 default is too
+#   low for brokers with many partitions/segments and triggers
+#   "Map failed". 262144 is the value recommended by Confluent's
+#   deployment guide.
+# vm.dirty_background_ratio / vm.dirty_ratio: begin writeback early and
+#   allow a large in-flight buffer to absorb write bursts.
+#   Ref: "Kafka: The Definitive Guide" 2nd Ed (O'Reilly), Ch.2, pp.80-81.
+#   Community best practice; not part of Apache Kafka official docs.
+kafka_pd_ssd_sysctl:
+  vm.max_map_count: "262144"
+  vm.dirty_background_ratio: "5"
+  vm.dirty_ratio: "60"

--- a/tasks/gcp-pd-ssd.yml
+++ b/tasks/gcp-pd-ssd.yml
@@ -1,0 +1,102 @@
+---
+# GCP Persistent Disk SSD (pd-ssd) disk + kernel tuning.
+# Included from tasks/main.yaml only when kafka_pd_ssd_tuning is true.
+# Safety contract documented in defaults/main/003-gcp-pd-ssd.yml.
+
+- name: Assert pd-ssd device is configured
+  ansible.builtin.assert:
+    that:
+      - kafka_pd_ssd_device | default('') | length > 0
+    fail_msg: >-
+      kafka_pd_ssd_tuning is true but kafka_pd_ssd_device is empty. Set it
+      to the attached GCP disk, e.g. /dev/disk/by-id/google-kafka-data.
+  tags:
+    - kafka_pd_ssd
+
+- name: Stat the pd-ssd block device
+  ansible.builtin.stat:
+    path: "{{ kafka_pd_ssd_device }}"
+  register: kafka_pd_ssd_dev_stat
+  tags:
+    - kafka_pd_ssd
+
+- name: Assert the pd-ssd block device exists
+  ansible.builtin.assert:
+    that:
+      - kafka_pd_ssd_dev_stat.stat.exists
+    fail_msg: >-
+      pd-ssd device {{ kafka_pd_ssd_device }} not found on
+      {{ inventory_hostname }}. Attach the disk before running.
+  tags:
+    - kafka_pd_ssd
+
+- name: Probe existing filesystem signature on pd-ssd device
+  ansible.builtin.command:
+    cmd: "blkid -p -s TYPE -o value {{ kafka_pd_ssd_device }}"
+  register: kafka_pd_ssd_blkid
+  changed_when: false
+  failed_when: false
+  become: true
+  tags:
+    - kafka_pd_ssd
+
+- name: Report pd-ssd filesystem decision
+  ansible.builtin.debug:
+    msg: >-
+      {{ kafka_pd_ssd_device }} existing filesystem:
+      '{{ kafka_pd_ssd_blkid.stdout | trim }}'
+      ->
+      {{ 'create ' ~ kafka_pd_ssd_fstype
+         if (kafka_pd_ssd_blkid.stdout | trim | length == 0)
+         else 'left untouched (no mkfs)' }}
+  tags:
+    - kafka_pd_ssd
+
+# force=false plus this when-guard are independent safeguards: an existing
+# filesystem signature means we skip mkfs entirely and never risk data loss.
+- name: Create filesystem on pd-ssd device (only when device has no filesystem)
+  community.general.filesystem:
+    fstype: "{{ kafka_pd_ssd_fstype }}"
+    dev: "{{ kafka_pd_ssd_device }}"
+    force: false
+  become: true
+  when: kafka_pd_ssd_blkid.stdout | trim | length == 0
+  tags:
+    - kafka_pd_ssd
+
+- name: Ensure Kafka data mount point exists
+  ansible.builtin.file:
+    path: "{{ kafka_data_log_dirs.split(',')[0] }}"
+    state: directory
+    mode: '0755'
+  become: true
+  tags:
+    - kafka_pd_ssd
+
+- name: Mount pd-ssd at the Kafka data directory and persist to fstab
+  ansible.posix.mount:
+    path: "{{ kafka_data_log_dirs.split(',')[0] }}"
+    src: "{{ kafka_pd_ssd_device }}"
+    fstype: "{{ kafka_pd_ssd_fstype }}"
+    opts: "{{ kafka_pd_ssd_mount_opts }}"
+    dump: '0'
+    passno: '0'
+    state: mounted
+  become: true
+  tags:
+    - kafka_pd_ssd
+
+- name: Apply pd-ssd kernel VM tuning
+  ansible.posix.sysctl:
+    name: "{{ item.key }}"
+    value: "{{ item.value }}"
+    state: present
+    sysctl_set: true
+    reload: true
+  loop: "{{ kafka_pd_ssd_sysctl | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}={{ item.value }}"
+  become: true
+  tags:
+    - kafka_pd_ssd
+    - kafka_sysctl

--- a/tasks/gcp-pd-ssd.yml
+++ b/tasks/gcp-pd-ssd.yml
@@ -35,7 +35,11 @@
     cmd: "blkid -p -s TYPE -o value {{ kafka_pd_ssd_device }}"
   register: kafka_pd_ssd_blkid
   changed_when: false
-  failed_when: false
+  # blkid exit codes: 0 = signature found, 2 = nothing found. Any other rc
+  # (missing binary, unreadable device, usage error) is a real failure and
+  # must abort the play -- otherwise an empty stdout would be misread as
+  # "no filesystem" and fall through to mkfs, defeating the safety contract.
+  failed_when: kafka_pd_ssd_blkid.rc not in [0, 2]
   become: true
   tags:
     - kafka_pd_ssd
@@ -49,6 +53,17 @@
       {{ 'create ' ~ kafka_pd_ssd_fstype
          if (kafka_pd_ssd_blkid.stdout | trim | length == 0)
          else 'left untouched (no mkfs)' }}
+  tags:
+    - kafka_pd_ssd
+
+# mkfs.<fstype> is not guaranteed to exist on minimal cloud images, so the
+# userspace tools must be installed before the filesystem is created.
+- name: Ensure filesystem tools for the pd-ssd filesystem are installed
+  ansible.builtin.package:
+    name: "{{ kafka_pd_ssd_fs_packages }}"
+    state: present
+  become: true
+  when: kafka_pd_ssd_fs_packages | length > 0
   tags:
     - kafka_pd_ssd
 

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -83,6 +83,15 @@
   tags:
     - kafka_sysctl
 
+# GCP pd-ssd disk + kernel tuning. Opt-in (default false), enabled only on
+# GCP hosts. Runs before data dirs are created/owned and before KRaft
+# storage is formatted so the data directory is on the pd-ssd mount.
+- name: Apply GCP pd-ssd disk and kernel tuning
+  ansible.builtin.include_tasks: gcp-pd-ssd.yml
+  when: kafka_pd_ssd_tuning | bool
+  tags:
+    - kafka_pd_ssd
+
 - name: Create kafka group
   ansible.builtin.group:
     name: '{{ kafka_group }}'


### PR DESCRIPTION
## What

Add an opt-in GCP Persistent Disk SSD (pd-ssd) tuning path to the role.

- New `tasks/gcp-pd-ssd.yml`, gated by `kafka_pd_ssd_tuning` (default **false**), included from `tasks/main.yaml` after the `vm.swappiness` task and before user/group creation + KRaft format.
- New defaults file `defaults/main/003-gcp-pd-ssd.yml` with the full safety contract.
- When enabled it: creates an **XFS** filesystem on `kafka_pd_ssd_device`, mounts it at the Kafka data dir with `noatime,nodiratime`, persists to fstab, and applies VM sysctl tuning (`vm.max_map_count=262144`, `vm.dirty_background_ratio=5`, `vm.dirty_ratio=60`).
- `CLAUDE.md` documents the variables and the safety contract.

## Safety

`mkfs` is **double-guarded**: a `blkid` probe skips the task entirely if any filesystem signature exists, and `community.general.filesystem` is invoked with `force: false`. An already-provisioned disk is never wiped — re-runs are idempotent.

## Notes

- Default off → no behavior change for existing consumers (molecule unaffected).
- Requires the `community.general` collection (added to the parent repo `requirements.yml`).
- `discard` is intentionally not set (GCP PD is not a raw SSD).

## Not verified

No GCP/molecule run possible without a real pd-ssd block device. Verified: YAML parse + logic review. First rollout should use `--check --diff` on one host.
